### PR TITLE
fix(deps): update dependencies and package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,33 +80,33 @@
     "composable-http-client",
     "composable-http-client-library"
   ],
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.13.1",
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^1.10.0",
     "zod": "^4.0.5"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
-    "@eslint/js": "^9.28.0",
-    "@types/node": "^24.0.1",
-    "@typescript-eslint/eslint-plugin": "^8.34.0",
-    "@typescript-eslint/parser": "^8.34.0",
-    "@vitest/coverage-v8": "^3.2.3",
+    "@eslint/js": "^9.31.0",
+    "@types/node": "^24.0.15",
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "all-contributors-cli": "^6.26.1",
-    "eslint": "^9.28.0",
+    "eslint": "^9.31.0",
     "husky": "^9.1.7",
-    "lint-staged": "^16.1.0",
-    "msw": "^2.10.2",
-    "prettier": "^3.5.3",
+    "lint-staged": "^16.1.2",
+    "msw": "^2.10.4",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^7.0.5",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.4"
   },
   "lint-staged": {
     "*.{ts}": [


### PR DESCRIPTION
- Bumped package manager to pnpm@10.13.1
- Updated axios to ^1.10.0
- Updated devDependencies:
  - @eslint/js to ^9.31.0
  - @types/node to ^24.0.15
  - @typescript-eslint/eslint-plugin and parser to ^8.37.0
  - @vitest/coverage-v8 to ^3.2.4
  - eslint to ^9.31.0
  - lint-staged to ^16.1.2
  - msw to ^2.10.4
  - prettier to ^3.6.2
  - vitest to ^3.2.4

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ⚡ Performance improvement

## Related issues

<!-- Link any related issues -->

Closes #

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Code follows style guidelines (`pnpm lint`)
- [ ] Added/updated tests for changes

## Additional notes

<!-- Any other context about the changes -->
