### PR TITLE
fix(deps): update dependencies and package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,33 +80,33 @@
     "composable-http-client",
     "composable-http-client-library"
   ],
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.13.1",
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^1.10.0",
     "zod": "^4.0.5"
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
-    "@eslint/js": "^9.28.0",
-    "@types/node": "^24.0.1",
-    "@typescript-eslint/eslint-plugin": "^8.34.0",
-    "@typescript-eslint/parser": "^8.34.0",
-    "@vitest/coverage-v8": "^3.2.3",
+    "@eslint/js": "^9.31.0",
+    "@types/node": "^24.0.15",
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "all-contributors-cli": "^6.26.1",
-    "eslint": "^9.28.0",
+    "eslint": "^9.31.0",
     "husky": "^9.1.7",
-    "lint-staged": "^16.1.0",
-    "msw": "^2.10.2",
-    "prettier": "^3.5.3",
+    "lint-staged": "^16.1.2",
+    "msw": "^2.10.4",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^7.0.5",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.4"
   },
   "lint-staged": {
     "*.{ts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: ^1.9.0
+        specifier: ^1.10.0
         version: 1.10.0
       zod:
         specifier: ^4.0.5
@@ -28,37 +28,37 @@ importers:
         specifier: ^19.8.1
         version: 19.8.1
       '@eslint/js':
-        specifier: ^9.28.0
+        specifier: ^9.31.0
         version: 9.31.0
       '@types/node':
-        specifier: ^24.0.1
+        specifier: ^24.0.15
         version: 24.0.15
       '@typescript-eslint/eslint-plugin':
-        specifier: ^8.34.0
+        specifier: ^8.37.0
         version: 8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser':
-        specifier: ^8.34.0
+        specifier: ^8.37.0
         version: 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       '@vitest/coverage-v8':
-        specifier: ^3.2.3
+        specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.0.15)(jiti@2.4.2)(msw@2.10.4(@types/node@24.0.15)(typescript@5.8.3))(yaml@2.8.0))
       all-contributors-cli:
         specifier: ^6.26.1
         version: 6.26.1
       eslint:
-        specifier: ^9.28.0
+        specifier: ^9.31.0
         version: 9.31.0(jiti@2.4.2)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^16.1.0
+        specifier: ^16.1.2
         version: 16.1.2
       msw:
-        specifier: ^2.10.2
+        specifier: ^2.10.4
         version: 2.10.4(@types/node@24.0.15)(typescript@5.8.3)
       prettier:
-        specifier: ^3.5.3
+        specifier: ^3.6.2
         version: 3.6.2
       typescript:
         specifier: ^5.8.3
@@ -70,7 +70,7 @@ importers:
         specifier: ^4.5.4
         version: 4.5.4(@types/node@24.0.15)(rollup@4.45.1)(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(yaml@2.8.0))
       vitest:
-        specifier: ^3.2.3
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@24.0.15)(jiti@2.4.2)(msw@2.10.4(@types/node@24.0.15)(typescript@5.8.3))(yaml@2.8.0)
 
 packages:


### PR DESCRIPTION
- Bumped package manager to pnpm@10.13.1
- Updated axios from ^1.9.0 to ^1.10.0
- Updated devDependencies:
  - @eslint/js from ^9.28.0 to ^9.31.0
  - @types/node from ^24.0.1 to ^24.0.15
  - @typescript-eslint/eslint-plugin from ^8.34.0 to ^8.37.0
  - @typescript-eslint/parser from ^8.34.0 to ^8.37.0
  - @vitest/coverage-v8 from ^3.2.3 to ^3.2.4
  - eslint from ^9.28.0 to ^9.31.0
  - lint-staged from ^16.1.0 to ^16.1.2
  - msw from ^2.10.2 to ^2.10.4
  - prettier from ^3.5.3 to ^3.6.2
  - vitest from ^3.2.3 to ^3.2.4

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ⚡ Performance improvement

## Related issues

<!-- Link any related issues -->

Closes #

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Code follows style guidelines (`pnpm lint`)
- [ ] Added/updated tests for changes

## Additional notes

<!-- Any other context about the changes -->
